### PR TITLE
Resolved various incorrect addresses in AZ1G900C

### DIFF
--- a/ECUFlash/subaru standard/Impreza WRX/AZ1G900C.xml
+++ b/ECUFlash/subaru standard/Impreza WRX/AZ1G900C.xml
@@ -161,7 +161,7 @@
 	</table>
 
 	<table name="Target Boost Compensation (ECT)" address="c088c">
-		<table name="Coolant Temperature" address="c07a4"/>
+		<table name="Coolant Temperature" address="c07ac"/>
 	</table>
 
 	<table name="Target Boost Compensation (1st Gear)" address="c07a4">
@@ -317,7 +317,7 @@
 	</table>
 
 	<table name="CL to OL Transition Counter Step Value (MAF)" address="c9e2c">
-		<table name="Mass Airflow" address="c9e08"/>
+		<table name="Mass Airflow" address="c9e04"/>
 	</table>
 
 	<table name="CL Delay Maximum (Throttle)" address="c7a28">
@@ -416,7 +416,7 @@
 	</table>
 
 	<table name="Throttle Tip-in Enrichment A" address="ca4fc">
-		<table name="Throttle Angle Change" address="ca4ac"/>
+		<table name="Throttle Angle Change" address="ca4b4"/>
 	</table>
 
 	<table name="Throttle Tip-in Enrichment B" address="ca568">
@@ -450,17 +450,17 @@
 	</table>
 
 	<table name="Tip-in Enrichment Compensation D (ECT)" address="ca5ec">
-		<table name="Coolant Temperature" address="c7e20"/>
+		<table name="Coolant Temperature" address="c7e60"/>
 	</table>
 
 	<table name="Min Primary Base Enrichment 1 Cruise" address="cb0f8">
 		<table name="Coolant Temperature" address="c7e20"/>
-		<table name="Engine Load" address="cb034" elements="9"/>
+		<table name="Engine Load" address="cb0d4" elements="9"/>
 	</table>
 
 	<table name="Min Primary Base Enrichment 1 Non-Cruise" address="cb054">
 		<table name="Coolant Temperature" address="c7e20"/>
-		<table name="Engine Load" address="cb0d4"/>
+		<table name="Engine Load" address="cb034"/>
 	</table>
 
 	<table name="Min Primary Base Enrichment 1 (Non-Primary OL)_" address="c811d">
@@ -574,7 +574,7 @@
 	<table name="Timing Compensation B (IAT) Max Additive" address="ce240">
 	</table>
 
-	<table name="Timing Compensation Imm. Cruise A (ECT)" address="ce78c">
+	<table name="Timing Compensation Imm. Cruise A (ECT)" address="ce78e">
 		<table name="Coolant Temperature" address="ce4f4"/>
 	</table>
 


### PR DESCRIPTION
Hi Merp,

I discovered a few addresses that were incorrect in the definitions for AZ1G900C. I suspect whoever created the defs in the first place maybe used a hex editor/diff method. I got these addresses directly from the table data in the rom.
