### PR TITLE
Updated D2UH001M.XML

### DIFF
--- a/ECUFlash/subaru metric/Liberty 3.0R/D2UH001M.xml
+++ b/ECUFlash/subaru metric/Liberty 3.0R/D2UH001M.xml
@@ -158,7 +158,7 @@
     <table name="X" address="c798c" />
     <table name="Y" address="c88e8" elements="14" />
   </table>
-  <table name="Base Timing C" address="c8a44">
+  <table name="Base Timing C (Main timing AVLS mode 3 enabled)" address="c8a44">
     <table name="X" address="c798c" />
     <table name="Y" address="c89f4" elements="20" />
   </table>
@@ -166,7 +166,7 @@
     <table name="X" address="c798c" />
     <table name="Y" address="c8b70" elements="20" />
   </table>
-  <table name="Base Timing E" address="c8d24">
+  <table name="Base Timing E (Main timing AVLS mode 1 enabled - Neutral or less than 17kph)" address="c8d24">
     <table name="X" address="c798c" />
     <table name="Y" address="c8cec" elements="14" />
   </table>
@@ -174,11 +174,11 @@
     <table name="X" address="c798c" />
     <table name="Y" address="c8df8" elements="14" />
   </table>
-  <table name="Base Timing G" address="c8f54">
+  <table name="Base Timing G (Main timing AVLS mode 3 enabled - Neutral)" address="c8f54">
     <table name="X" address="c798c" />
     <table name="Y" address="c8f04" elements="20" />
   </table>
-  <table name="Base Timing H" address="c90d0">
+  <table name="Base Timing H (Main timing AVLS mode 1 enabled - above 17kph)" address="c90d0">
     <table name="X" address="c798c" />
     <table name="Y" address="c9080" elements="20" />
   </table>
@@ -192,11 +192,11 @@
     <table name="Y" address="c7968" />
   </table>
   <table name="Base Timing Idle Vehicle Speed Threshold" address="c76c4" />
-  <table name="Knock Correction Advance Max A" address="c92b8">
+  <table name="Knock Correction Advance Max A (AVLS mode 1 enabled)" address="c92b8">
     <table name="X" address="c9244" elements="15" />
     <table name="Y" address="c9280" elements="14" />
   </table>
-  <table name="Knock Correction Advance Max B" address="c9418">
+  <table name="Knock Correction Advance Max B (AVLS mode 3 enabled)" address="c9418">
     <table name="X" address="c938c" elements="15" />
     <table name="Y" address="c93c8" elements="20" />
   </table>
@@ -243,15 +243,23 @@
   </table>
   <table name="Advance Multiplier (Initial)" address="c78a8" />
   <table name="Advance Multiplier Step Value" address="c78d0" />
-  <table name="Requested Torque A (Accelerator Pedal)" address="dc6bc">
+  <table name="Intake Cam Advance Angle A (AVCS) - AVLS mode 1 active" address="cd228">
+  <table name="Engine Load" address="cd1c4" elements="14"/>
+	<table name="Engine Speed" address="cd1fc" elements="11"/>
+	</table>
+  <table name="Intake Cam Advance Angle B (AVCS) - AVLS mode 3 active" address="cd3dc">
+	<table name="Engine Load" address="cd35c" elements="14"/>
+	<table name="Engine Speed" address="cd394" elements="18"/>
+	</table>
+  <table name="Requested Torque A (Accelerator Pedal) SI - 'S'" address="dc6bc">
     <table name="X" address="dc61c" elements="20" />
     <table name="Y" address="dc66c" elements="20" />
   </table>
-  <table name="Requested Torque B (Accelerator Pedal)" address="dca7c">
+  <table name="Requested Torque B (Accelerator Pedal) SI - 'I'" address="dca7c">
     <table name="X" address="dc9dc" elements="20" />
     <table name="Y" address="dca2c" elements="20" />
   </table>
-  <table name="Requested Torque C (Accelerator Pedal)" address="dce3c">
+  <table name="Requested Torque C (Accelerator Pedal) SI - 'S#'" address="dce3c">
     <table name="X" address="dcd9c" elements="20" />
     <table name="Y" address="dcdec" elements="20" />
   </table>


### PR DESCRIPTION
Added AVCS tables and specified A and B conditions.
Updated description for "Requested torque" tables to reflect which SI drive mode selected.
Updated description for some ignition tables  to reflect which is being used under what condition.
Updated description for knock advance tables to reflect which is being used under what condition.
Working on AVLS tables with two RR members, will update once confirmed

Please check to make sure I haven't buggered anything else up in the process :)